### PR TITLE
Add recipe instructions to back of the recipe cards

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -36,7 +36,10 @@
         <button type="button" class="exit-recipe-btn " id="exitRecipe">&#10006;</button>
         <button type="button" class="flip-recipe-btn " id="flipRecipe">&#10150;</button>
         <section class="recipe-info" id="recipeInfo">
-
+          <div class="recipe-front" id="recipeFront">
+          </div>
+          <div class="recipe-back hidden" id="recipeBack">
+          </div>
         </section>
       </section>
       <article class="you-should-try" id="recipesBox">

--- a/src/recipe.js
+++ b/src/recipe.js
@@ -37,7 +37,11 @@ class Recipe {
   }
 
   returnInstructions() {
-    return this.instructions;
+    let stringInstructions = ' '
+    this.instructions.forEach(instruction => {
+      stringInstructions += `${instruction.number}. ${instruction.instruction} </br> </br>`
+    });
+    return stringInstructions;
   }
 }
 

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -60,6 +60,10 @@ function cardPress() {
     recipeFront.innerHTML = ''
     recipeBack.innerHTML = ''
     unhideRecipeCard()
+    if(!recipeBack.classList.contains('hidden')){
+      recipeFront.classList.toggle('hidden')
+      showInstructions()
+    }
   } else if (event.target.id === 'flipRecipe') {
     showInstructions()
     recipeFront.classList.toggle('hidden')

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -5,7 +5,8 @@ const userKitchen = document.querySelector('#userDropdown');
 const recipeChart = document.querySelector('#recipes');
 const recipesBox = document.querySelector('#recipesBox');
 const recipeCard = document.querySelector('#recipeCard');
-const recipeInfo = document.querySelector('#recipeInfo');
+const recipeFront = document.querySelector('#recipeFront');
+const recipeBack = document.querySelector('#recipeBack')
 const instructions = document.querySelector('#instructions');
 const searchBar = document.querySelector('.search-bar');
 
@@ -48,7 +49,7 @@ function navPress() {
 
 function mainPress() {
   let click = event.target.id;
-  const card = allRecipes.recipes.find(recipe => recipe.id === click)
+  const card = allRecipes.recipes.find(recipe => recipe.id == click)
   if (card) {
     showRecipe(card)
   }
@@ -56,30 +57,27 @@ function mainPress() {
 
 function cardPress() {
   if (event.target.id === 'exitRecipe') {
-    recipeInfo.innerHTML = ''
+    recipeFront.innerHTML = ''
+    recipeBack.innerHTML = ''
     unhideRecipeCard()
   } else if (event.target.id === 'flipRecipe') {
     showInstructions()
-    recipeInfo.classList.toggle('hidden')
+    recipeFront.classList.toggle('hidden')
   }
 }
 
 function showRecipe(recipe) {
   unhideRecipeCard()
-
-  recipeInfo.innerHTML += `<img src=${recipe.image} alt=${recipe.name}>
+  console.log(recipeFront)
+  recipeFront.innerHTML += `<img src=${recipe.image} alt=${recipe.name}>
   <h2 class="recipeTitle card-text">${recipe.name}</h2>
   <h3 class="cost card-text">Cost: $${recipe.returnTotalCost(ingredientsData)}</h3>
   <h4 class="cost card-text">Ingredients: ${recipe.returnIngredientNames(ingredientsData)}</h4>`
-  // <ol class="hidden" id="instructions">
-  // ${recipe.instructions.forEach(step => {
-  //   return `<li>${step.instruction}</li>`
-  // })}
-  // </ol>`
+  recipeBack.innerHTML += `<p class="instruction-text"> ${recipe.returnInstructions()} </p>`
 }
 
 function showInstructions(recipe) {
-//  instructions.classList.toggle('hidden')
+  recipeBack.classList.toggle('hidden')
 }
 
 function unhideRecipeCard() {

--- a/src/styles.css
+++ b/src/styles.css
@@ -98,6 +98,15 @@ text-shadow: 0px 1px #184A45FF,
 -1px 0px #184A45FF;
 }
 
+.recipe-info {
+  height: 476px;
+  overflow-y: scroll;
+}
+
+.instruction-text {
+  color: #184A45FF;
+}
+
 .card-text {
 color: #184A45FF;
 }
@@ -272,7 +281,7 @@ transition: max-height 0.5s ease-out;
 /* VISIBILITY */
 
 .hidden {
-visibility:hidden;
+display:none;
 }
 
 .collapsed {


### PR DESCRIPTION
## Pull Request

<br>

### Description

* Is this a feature or a fix?
Feature.

* Where should the reviewer start?
in the ./src/scripts.js, ./src/index.html, and ./src/styles.css files. Look specifically at the bottom of the **RECIPE CARD** section (Line 101 and below) of the css for a few added styles. 
Look at line 38-42 of Index.html to see added divs (for styling purposes only).
 Check also into the scripts.js file specifically on line 58 and 69( cardPress and showRecipe functions) for new lines of code.

* What functionalities do these changes effect? Why were these changes made? What was the motivation behind these changes?
This allows a user to flip the card over and view the instructions on how to make the recipe!

* What outside features or research did you use to implement this fix?
N/A

* How should this be tested?
Open your console. CD into the repo. Then open index.html in your browser. Click on a recipe and test flipping over the card (bottom right corner of the card). 

<br>

***

#### Please review considerations below:

- [x] Follows Turing Style Guidelines

- [x] Changes generate no new warnings or errors

- [x] Checked code for and corrected any spelling errors

- [x] README has been updated(if applicable)