### PR TITLE
Fix/ingredient amounts

### DIFF
--- a/src/recipe.js
+++ b/src/recipe.js
@@ -43,6 +43,20 @@ class Recipe {
     });
     return stringInstructions;
   }
+
+  returnIngredients() {
+    let stringIngredients = ' '
+    this.ingredients.forEach(ingredient => {
+      let ingName;
+      ingredientsData.forEach(searchIngredient => {
+        if (ingredient.id === searchIngredient.id) {
+          ingName = searchIngredient.name;
+        }
+      })
+      stringIngredients += `${ingredient.quantity.amount} ${ingredient.quantity.unit} ${ingName} </br> </br>`
+    });
+    return stringIngredients;
+  }
 }
 
 

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -76,7 +76,7 @@ function showRecipe(recipe) {
   recipeFront.innerHTML += `<img src=${recipe.image} alt=${recipe.name}>
   <h2 class="recipeTitle card-text">${recipe.name}</h2>
   <h3 class="cost card-text">Cost: $${recipe.returnTotalCost(ingredientsData)}</h3>
-  <h4 class="cost card-text">Ingredients: ${recipe.returnIngredientNames(ingredientsData)}</h4>`
+  <h4 class="cost card-text"><u>Ingredients:</u> </br> ${recipe.returnIngredients()}</h4>`
   recipeBack.innerHTML += `<p class="instruction-text"> ${recipe.returnInstructions()} </p>`
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -103,6 +103,17 @@ text-shadow: 0px 1px #184A45FF,
   overflow-y: scroll;
 }
 
+.recipe-info::-webkit-scrollbar {
+  background-color: #FC766AFF;
+  width: 6px;
+}
+
+.recipe-info::-webkit-scrollbar-thumb {
+  background-color: #184A45FF;
+  border-radius: 4px;
+  width:4px;
+}
+
 .instruction-text {
   color: #184A45FF;
 }
@@ -212,6 +223,27 @@ transition: max-height 0.5s ease-out;
   height: 75%;
 }
 
+.you-can-make-list::-webkit-scrollbar {
+  background-color: #B0B8B4FF;
+  width: 6px;
+}
+
+.you-can-make-list::-webkit-scrollbar-thumb {
+  background-color: #FC766AFF;
+  border-radius: 4px;
+  width:4px;
+}
+
+.ingredient-list::-webkit-scrollbar {
+  background-color: #B0B8B4FF;
+  width: 6px;
+}
+
+.ingredient-list::-webkit-scrollbar-thumb {
+  background-color: #FC766AFF;
+  border-radius: 4px;
+  width:4px;
+}
 
 /* RECIPE SHOWCASE */
 
@@ -234,6 +266,17 @@ transition: max-height 0.5s ease-out;
   overflow-y: scroll;
   height:90%;
   margin: 0px 25px;
+}
+
+.random-recipe-bar::-webkit-scrollbar {
+  background-color: #184A45FF;
+  width: 9px;
+}
+
+.random-recipe-bar::-webkit-scrollbar-thumb {
+  background-color: #FC766AFF;
+  border-radius: 6px;
+  width:6px;
 }
 
 .dropbtn {

--- a/src/styles.css
+++ b/src/styles.css
@@ -99,7 +99,7 @@ text-shadow: 0px 1px #184A45FF,
 }
 
 .recipe-info {
-  height: 476px;
+  height: 100%;
   overflow-y: scroll;
 }
 
@@ -154,7 +154,6 @@ transform: translate(-50%, -50%);
   justify-self: center;
   width: 50%;
 }
-
 
 .home-recipes {
   justify-content: space-evenly;


### PR DESCRIPTION
Fixes #
## Improves ingredient display on large recipe card pop-up. Adds scrollbar styling.

<br>

### Description

* Is this a feature or a fix?
This is a fix.

* Where should the reviewer start?
Reviewer can start with opening `index.html` on their web browser, as well as `styles.css` `recipe.js` `scripts.js` and `index.html` in their code editor.

* What functionalities do these changes effect? Why were these changes made? What was the motivation behind these changes?  
On recipe cards rather than displaying a block of ingredients (like one would find on a food package) it now shows a list of ingredients and their quantities.   
Scrollbars are also styled to match color scheme of various objects they are on.

* What outside features or research did you use to implement this fix?
CSS tricks info on scrollbars was a life saver. Also utilized instruction method as framework for ingredient display (see `recipe.js`)

* How should this be tested?
In the browser showing `index.html` click on recipe cards to view ingredient lists. Recipe cards, recipe grid, and What's Cookin' dropdown should all have more discreet scrollbars.

<br>

***

#### Please review considerations below:

- [x] Opened Files Reflect Proper Syntax/Styling
- [x] Opened Files Have Been Checked With a Linter
- [x] Opened Files Have Been Checked For Refactor Opportunities